### PR TITLE
Password less sudo does not work for the 'vagrant' user

### DIFF
--- a/definitions/ubuntu-12.04.3-amd64-vbox/vagrant.sh
+++ b/definitions/ubuntu-12.04.3-amd64-vbox/vagrant.sh
@@ -2,8 +2,8 @@ set -ex
 
 date > /etc/vagrant_box_build_time
 
-# Setup sudo to allow no-password sudo for "sudo"
-usermod -a -G sudo vagrant
+# Add vagrant to the group which allows  no-password sudo ("vagrant")
+usermod -a -G vagrant vagrant
 
 # Set root password
 echo 'root:vagrant' | chpasswd


### PR DESCRIPTION
I enjoy using your vagrant boxes and like the fact that you have published the scripts used to bootstrap them.

However today I realised that password less sudo did not work in the box, which apparently is against Vagrant's conventions.
#### reproduction steps
- build a box, using master
- extract the box (`tar -xf [boxname]`) and import it into your vm software
- start the vm, log in with `vagrant/vagrant`
- `sudo su`: it ask for a password
#### fix
- add `vagrant` user to the `vagrant` group which was setup for password less sudo

This change works for me on OS X 10.9/Virtualbox 4.3.0.
