### PR TITLE
Error building ubuntu-14.04 for vmware_fusion

### DIFF
--- a/definitions/ubuntu-14.04-amd64-vbox/_cleanup.sh
+++ b/definitions/ubuntu-14.04-amd64-vbox/_cleanup.sh
@@ -15,6 +15,7 @@ apt-get -y autoremove
 apt-get clean
 
 # Clean up tmp
+sleep 5
 rm -rf /tmp/*
 
 # Removing leftover leases and persistent rules


### PR DESCRIPTION
First, many thanks for putting together those templates and bringing veewee to my attention.

I tried building the ubuntu-14.04 image myself, without any modifications.

```
$ git log -1 | head -1
commit 3327c75eb7e352c34350e4b6ee8a0be5ed7547b2
$ bundle install --path vendor
$ bundle exec rake vmware_fusion:ubuntu-14.04-amd64:all
mkdir -p iso
```

The script went on smoothly, but after a couple of minutes I noticed I had to enter the password manually (vagrant/vagrant). This didn't seem to stop the process. A little later, however, veewee tried to remove a non-empty folder, halting the script.

```
rm -rf /tmp/mkinitramfs-OL_Hw1YrR /tmp/mkinitramfs_ZoaijZ
rm: cannot remove ‘/tmp/mkinitramfs_ZoaijZ/lib/modules/3.13.0-43-generic/kernel/drivers’: Directory not empty
```

A more complete log output

```
$ bundle exec rake vmware_fusion:ubuntu-14.04-amd64:all
...
...
...
+ sleep 5
+ apt-get remove -y build-essential
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following packages will be REMOVED:
  build-essential
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 37.9 kB disk space will be freed.
(Reading database ... 105077 files and directories currently installed.)
Removing build-essential (11.6ubuntu6) ...
+ apt-get -y autoremove
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following packages will be REMOVED:
  g++ g++-4.8 libstdc++-4.8-dev
0 upgraded, 0 newly installed, 3 to remove and 0 not upgraded.
After this operation, 29.6 MB disk space will be freed.
(Reading database ... 105068 files and directories currently installed.)
Removing g++ (4:4.8.2-1ubuntu6) ...
Removing g++-4.8 (4.8.2-19ubuntu1) ...
Removing libstdc++-4.8-dev:amd64 (4.8.2-19ubuntu1) ...
Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
+ apt-get clean
+ rm -rf /tmp/mkinitramfs-OL_Hw1YrR /tmp/mkinitramfs_ZoaijZ /tmp/vmware-config0 /tmp/VMwareDnD /tmp/vmware-fonts0 /tmp/vmware-fonts1 /tmp/vmware-installer0 /tmp/vmware-root /tmp/vmware-root-2082814844 /tmp/vmware-tools-distrib
rm: cannot remove ‘/tmp/mkinitramfs_ZoaijZ/lib/modules/3.13.0-43-generic/kernel/drivers’: Directory not empty
Connection to 192.168.120.131 closed.
rake aborted!
Command failed with status (1): [bundle exec veewee fusion ssh ubuntu-14.04...]
/Users/tristan/Code/Vendor/open-vagrant-boxes/Rakefile:105:in `block (2 levels) in <top (required)>'
Tasks: TOP => vmware_fusion:ubuntu-14.04-amd64:all => vmware_fusion:ubuntu-14.04-amd64:fixup_image
(See full trace by running task with --trace)
```

For full output, see https://gist.github.com/trkoch/92561a886da5c4c2b69b.

Any ideas?
