### PR TITLE
Allow vagrant user NOPASSWD sudo to all accounts

### DIFF
--- a/definitions/ubuntu-12.04-amd64-vbox/base.sh
+++ b/definitions/ubuntu-12.04-amd64-vbox/base.sh
@@ -8,7 +8,7 @@ apt-get -y install build-essential vim curl
 
 # Set up sudo
 ( cat <<'EOP'
-%vagrant ALL=NOPASSWD:ALL
+%vagrant ALL=(ALL) NOPASSWD:ALL
 EOP
 ) > /tmp/vagrant
 chmod 0440 /tmp/vagrant

--- a/definitions/ubuntu-12.04-amd64-vbox/vagrant.sh
+++ b/definitions/ubuntu-12.04-amd64-vbox/vagrant.sh
@@ -2,9 +2,6 @@ set -ex
 
 date > /etc/vagrant_box_build_time
 
-# Setup sudo to allow no-password sudo for "sudo"
-usermod -a -G sudo vagrant
-
 # Set root password
 echo 'root:vagrant' | chpasswd
 

--- a/definitions/ubuntu-14.04-amd64-vbox/base.sh
+++ b/definitions/ubuntu-14.04-amd64-vbox/base.sh
@@ -9,7 +9,7 @@ apt-get -y install vim curl
 
 # Set up sudo
 ( cat <<'EOP'
-%vagrant ALL=NOPASSWD:ALL
+%vagrant ALL=(ALL) NOPASSWD:ALL
 EOP
 ) > /tmp/vagrant
 chmod 0440 /tmp/vagrant

--- a/definitions/ubuntu-14.04-amd64-vbox/vagrant.sh
+++ b/definitions/ubuntu-14.04-amd64-vbox/vagrant.sh
@@ -2,9 +2,6 @@ set -ex
 
 date > /etc/vagrant_box_build_time
 
-# Setup sudo to allow no-password sudo for "sudo"
-usermod -a -G sudo vagrant
-
 # Set root password
 echo 'root:vagrant' | chpasswd
 


### PR DESCRIPTION
At the moment, the vagrant user can run any command as root without a password, but to run commands as any other user requires a password. This commit allows the vagrant user to run any command as any user with no password. This is achieved by adding an `ALL` _Runas_Spec_ to the entry in `/etc/sudoers.d/vagrant`.
